### PR TITLE
feat(reset-delete): enable reset and delete for curr user

### DIFF
--- a/src/shared/fetchServiceAccounts.ts
+++ b/src/shared/fetchServiceAccounts.ts
@@ -51,8 +51,6 @@ export async function fetchServiceAccounts({
     state = hasNextPageData.length === 2 ? RESULTS : LAST_PAGE;
   }
 
-  console.log(state, data, 'this is state and data!');
-
   return {
     serviceAccounts: [
       ...data,


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

If I created service account I should be able to remove it and reset its credentials even without specific rights. Also if I have `rbac:*:*` permissions I should be able to remove any service account similar to how org admins can.

[RHCLOUD-28696](https://issues.redhat.com/browse/RHCLOUD-28696)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:

<img width="1625" height="444" alt="Screenshot 2025-09-04 at 10 28 05" src="https://github.com/user-attachments/assets/43b2bfef-401d-4eb6-b5d6-a0a29658130d" />

#### After:
<img width="1620" height="447" alt="Screenshot 2025-09-04 at 10 27 33" src="https://github.com/user-attachments/assets/f4d156fa-3e76-4703-be98-d4bb0f82dedb" />


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
