### PR TITLE
fix: prevent InputGroupText wrapping and ensure left alignment

### DIFF
--- a/src/shared/ServiceAccountNameSecretModal.tsx
+++ b/src/shared/ServiceAccountNameSecretModal.tsx
@@ -71,8 +71,11 @@ export const ServiceAccountNameSecretModal: VoidFunctionComponent<{
                 </Content>
               </Content>
               <InputGroup className="pf-u-mt-lg">
-                <InputGroupText className="pf-u-text-nowrap">
-                  Client&nbsp;ID
+                <InputGroupText 
+                  className="pf-u-text-nowrap pf-u-flex-shrink-0"
+                  style={{ minWidth: '120px', textAlign: 'left' }}
+                >
+                  Client ID
                 </InputGroupText>
                 <InputGroupItem className="pf-v6-u-w-100">
                   <ClipboardCopy
@@ -87,8 +90,11 @@ export const ServiceAccountNameSecretModal: VoidFunctionComponent<{
                 </InputGroupItem>
               </InputGroup>
               <InputGroup className="pf-u-mt-md">
-                <InputGroupText className="pf-u-text-nowrap">
-                  Client&nbsp;secret
+                <InputGroupText 
+                  className="pf-u-text-nowrap pf-u-flex-shrink-0"
+                  style={{ minWidth: '120px', textAlign: 'left' }}
+                >
+                  Client secret
                 </InputGroupText>
                 <InputGroupItem className="pf-v6-u-w-100">
                   <ClipboardCopy

--- a/src/shared/ServiceAccountNameSecretModal.tsx
+++ b/src/shared/ServiceAccountNameSecretModal.tsx
@@ -90,7 +90,7 @@ export const ServiceAccountNameSecretModal: VoidFunctionComponent<{
                 </InputGroupItem>
               </InputGroup>
               <InputGroup className="pf-u-mt-md">
-                <InputGroupText 
+                <InputGroupText
                   className="pf-u-text-nowrap pf-u-flex-shrink-0"
                   style={{ minWidth: '120px', textAlign: 'left' }}
                 >

--- a/src/shared/ServiceAccountNameSecretModal.tsx
+++ b/src/shared/ServiceAccountNameSecretModal.tsx
@@ -71,7 +71,7 @@ export const ServiceAccountNameSecretModal: VoidFunctionComponent<{
                 </Content>
               </Content>
               <InputGroup className="pf-u-mt-lg">
-                <InputGroupText 
+                <InputGroupText
                   className="pf-u-text-nowrap pf-u-flex-shrink-0"
                   style={{ minWidth: '120px', textAlign: 'left' }}
                 >


### PR DESCRIPTION
- Add pf-u-text-nowrap and pf-u-flex-shrink-0 utility classes
- Set minWidth: 120px and textAlign: left via inline styles
- Ensures consistent width and prevents text wrapping for both Client ID and Client secret labels

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->


[RHCLOUD-42079](https://issues.redhat.com/browse/RHCLOUD-42079)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="803" height="618" alt="Screenshot 2025-09-15 at 1 20 56 PM" src="https://github.com/user-attachments/assets/99358b59-1dd3-499a-a464-09f92d4fdd7f" />

#### After:
<img width="796" height="600" alt="Screenshot 2025-09-15 at 1 58 12 PM" src="https://github.com/user-attachments/assets/e6b45642-c486-45a7-a5f0-c33b15f7e044" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
